### PR TITLE
added required centos package: file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ RUN > /var/log/yum.log && \
 		   gcc-c++ \
 		   zlib-devel \
 		   perl-ExtUtils-Embed \
-		   perl-devel
+		   perl-devel \
+		   file
+
 		   
 RUN curl -L -o net-snmp-5.7.3.tar.gz 'http://downloads.sourceforge.net/project/net-snmp/net-snmp/5.7.3/net-snmp-5.7.3.tar.gz?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Fnet-snmp%2Ffiles%2Fnet-snmp%2F5.7.3%2F&ts=1443006025&use_mirror=skylink' && \
     tar zxf net-snmp-5.7.3.tar.gz


### PR DESCRIPTION
Hi

I'm working with this repo, and I noted that I need to install file package in order to compile net-snmp.

May be a new requisite from CentOS 7.

Best,
